### PR TITLE
Feature/src tx finality (318)

### DIFF
--- a/src/managers/ConceroNetworkManager.ts
+++ b/src/managers/ConceroNetworkManager.ts
@@ -141,6 +141,10 @@ export class ConceroNetworkManager extends ManagerBase implements IConceroNetwor
         }
     }
 
+	public getDefaultFinalityConfirmations(): number {
+		return this.config.defaultFinalityConfirmations;
+	}
+
     public async forceUpdate(): Promise<void> {
         await this.updateNetworks();
     }
@@ -276,6 +280,7 @@ export class ConceroNetworkManager extends ManagerBase implements IConceroNetwor
                         chainSelector: network.chainSelector || network.chainId.toString(),
                         confirmations: this.config.defaultConfirmations,
                         viemChain: network.viemChain,
+                        finalityConfirmations: network.finalityConfirmations || this.config.defaultFinalityConfirmations,
                     },
                 ];
             }),

--- a/src/managers/TxMonitor.ts
+++ b/src/managers/TxMonitor.ts
@@ -21,11 +21,7 @@ enum TransactionStatus {
 
 interface TransactionMonitor {
     transaction: MonitoredTransaction;
-    retryCallback: (failedTx: TransactionInfo) => Promise<TransactionInfo | null>;
-    finalityCallback: (finalizedTx: TransactionInfo) => void;
-    retryCount: number;
-    lastRetryAt?: number;
-    canRetry: boolean;
+    subscribers: Map<string, (txInfo: TransactionInfo, isFinalized: boolean) => void>;
     finalityBlockNumber?: bigint;
 }
 
@@ -37,8 +33,6 @@ export class TxMonitor implements ITxMonitor {
     private logger: LoggerInterface;
     private config: TxMonitorConfig;
     private networkSubscriptions: Map<string, () => void> = new Map();
-    private networksWithTransactions: Set<string> = new Set();
-    private networkLastActivity: Map<string, number> = new Map();
     private blockManagerRegistry: IBlockManagerRegistry;
     private networkManager: IConceroNetworkManager;
 
@@ -83,63 +77,65 @@ export class TxMonitor implements ITxMonitor {
         return TxMonitor.instance;
     }
 
-    public watchTxFinality(
+    public ensureTxFinality(
         txInfo: TransactionInfo,
-        retryCallback: (failedTx: TransactionInfo) => Promise<TransactionInfo | null>,
-        finalityCallback: (finalizedTx: TransactionInfo) => void,
-        canRetry?: boolean,
+        onFinalityCallback: (txInfo: TransactionInfo, isFinalized: boolean) => void,
     ): void {
-        if (this.monitors.has(txInfo.txHash)) {
-            this.logger.debug(`Transaction ${txInfo.txHash} is already being monitored`);
+        const existingMonitor = this.monitors.get(txInfo.txHash);
+
+        if (existingMonitor) {
+            // Add subscriber to existing monitor
+            existingMonitor.subscribers.set(txInfo.id, onFinalityCallback);
+            this.logger.debug(
+                `Added subscriber ${txInfo.id} to existing monitor for tx ${txInfo.txHash}`,
+            );
             return;
         }
 
+        // Create new monitor
         const monitoredTx: MonitoredTransaction = {
             txHash: txInfo.txHash,
             chainName: txInfo.chainName,
+            submittedAt: txInfo.submittedAt,
             blockNumber: txInfo.submissionBlock,
-            firstSeen: Date.now(),
-            lastChecked: Date.now(),
             status: TransactionStatus.Pending,
-            managedTxId: txInfo.id,
         };
 
         const monitor: TransactionMonitor = {
             transaction: monitoredTx,
-            retryCallback,
-            finalityCallback,
-            retryCount: 0,
-            canRetry: canRetry ?? true,
+            subscribers: new Map(),
             finalityBlockNumber: undefined,
         };
+
+        // Add the subscriber for this specific transaction ID
+        monitor.subscribers.set(txInfo.id, onFinalityCallback);
 
         this.subscribeToNetwork(txInfo.chainName);
 
         this.monitors.set(txInfo.txHash, monitor);
-        this.logger.debug(`Started monitoring tx ${txInfo.txHash} on ${txInfo.chainName}`);
+        this.logger.debug(
+            `Started monitoring tx ${txInfo.txHash} on ${txInfo.chainName} with subscriber ${txInfo.id}`,
+        );
     }
 
     public addTransaction(txHash: string, txInfo: TransactionInfo): void {
-        // This method is kept for backward compatibility but delegates to watchTxFinality
-        this.logger.warn(`addTransaction called directly - use watchTxFinality instead`);
+        // This method is kept for backward compatibility but delegates to ensureTxFinality
+        this.logger.warn(`addTransaction called directly - use ensureTxFinality instead`);
 
-        // Create default callbacks for backward compatibility
-        const defaultRetryCallback = async (
-            failedTx: TransactionInfo,
-        ): Promise<TransactionInfo | null> => {
-            this.logger.warn(
-                `Transaction ${failedTx.txHash} failed but no retry callback provided`,
-            );
-            return null;
+        // Create default callback for backward compatibility
+        const defaultCallback = (finalizedTx: TransactionInfo, isFinalized: boolean): void => {
+            if (isFinalized) {
+                this.logger.info(
+                    `Transaction ${finalizedTx.txHash} (${finalizedTx.id}) finalized (using legacy addTransaction)`,
+                );
+            } else {
+                this.logger.warn(
+                    `Transaction ${finalizedTx.txHash} (${finalizedTx.id}) failed (using legacy addTransaction)`,
+                );
+            }
         };
 
-        const defaultFinalityCallback = (finalizedTx: TransactionInfo): void => {
-            this.logger.info(
-                `Transaction ${finalizedTx.txHash} finalized (using legacy addTransaction)`,
-            );
-        };
-
-        this.watchTxFinality(txInfo, defaultRetryCallback, defaultFinalityCallback);
+        this.ensureTxFinality(txInfo, defaultCallback);
     }
 
     private async checkTransactionFinality(
@@ -149,7 +145,6 @@ export class TxMonitor implements ITxMonitor {
         network: ConceroNetwork,
     ): Promise<void> {
         const tx = monitor.transaction;
-        tx.lastChecked = Date.now();
 
         try {
             const { publicClient } = this.viemClientManager.getClients(network);
@@ -158,7 +153,7 @@ export class TxMonitor implements ITxMonitor {
             });
 
             if (!txInfo) {
-                await this.handleMissingTransaction(monitor, network);
+                await this.notifySubscribers(monitor, network, false);
                 return;
             }
 
@@ -190,110 +185,44 @@ export class TxMonitor implements ITxMonitor {
             }
 
             // Transaction has reached finality - this should only be called when we're sure
-            await this.handleFinalizedTransaction(monitor);
+            await this.notifySubscribers(monitor, network, true);
         } catch (error) {
             this.logger.error(`Error checking transaction ${tx.txHash}:`, error);
 
-            // If there's a persistent error, consider retrying the transaction
-            const timeSinceLastRetry = tx.lastChecked - (monitor.lastRetryAt || 0);
-            const retryDelayMs = this.config.retryDelayMs || 30000;
-
-            if (timeSinceLastRetry > retryDelayMs) {
-                await this.retryTransaction(monitor, network);
-            }
+            await this.notifySubscribers(monitor, network, false);
         }
     }
 
-    private async handleMissingTransaction(
+    private async notifySubscribers(
         monitor: TransactionMonitor,
         network: ConceroNetwork,
+        isFinalized: boolean,
     ): Promise<void> {
         const tx = monitor.transaction;
 
-        // Give the transaction some time before considering it dropped
-        const timeSinceSubmission = Date.now() - tx.firstSeen;
-        const dropTimeoutMs = this.config.dropTimeoutMs || 60000;
-
-        if (timeSinceSubmission < dropTimeoutMs) {
-            this.logger.debug(
-                `Transaction ${tx.txHash} not found yet (${timeSinceSubmission}ms since submission)`,
-            );
-            return;
-        }
-
-        tx.status = TransactionStatus.Dropped;
-        this.logger.warn(
-            `Transaction ${tx.txHash} not found on chain ${network.name} after ${timeSinceSubmission}ms`,
-        );
-
-        await this.retryTransaction(monitor, network);
-    }
-
-    private async retryTransaction(
-        monitor: TransactionMonitor,
-        network: ConceroNetwork,
-    ): Promise<void> {
-        // If can't retry, stop monitoring
-        if (!monitor.canRetry) {
-            this.logger.info(
-                `Transaction ${monitor.transaction.txHash} is observe-only, stopping monitoring after failure`,
-            );
-            await this.removeMonitor(monitor.transaction.txHash);
-            return;
-        }
-
-        const tx = monitor.transaction;
-        monitor.retryCount++;
-        monitor.lastRetryAt = Date.now();
-
+        const txStatus = isFinalized ? TransactionStatus.Finalized : TransactionStatus.Failed;
         this.logger.info(
-            `Retrying transaction ${tx.txHash} on ${network.name} (attempt ${monitor.retryCount})`,
+            `Transaction ${tx.txHash} ${txStatus} on ${network.name} - notifying subscribers`,
         );
 
-        // Create a TransactionInfo from MonitoredTransaction for the retry callback
-        const failedTx: TransactionInfo = {
-            id: tx.managedTxId,
+        const txResult: TransactionInfo = {
+            id: '', // Will be set per subscriber
             txHash: tx.txHash,
             chainName: tx.chainName,
-            submittedAt: tx.firstSeen,
+            submittedAt: tx.submittedAt,
             submissionBlock: tx.blockNumber,
-            status: 'failed',
+            status: txStatus,
         };
 
-        const newTxInfo = await monitor.retryCallback(failedTx);
+        // Notify all subscribers
+        monitor.subscribers.forEach((callback, subscriberId) => {
+            const txForSubscriber: TransactionInfo = {
+                ...txResult,
+                id: subscriberId,
+            };
+            callback(txForSubscriber, isFinalized);
+        });
 
-        if (newTxInfo) {
-            // Remove the old monitor
-            await this.removeMonitor(tx.txHash);
-
-            // Add new monitor for the retry transaction
-            this.watchTxFinality(newTxInfo, monitor.retryCallback, monitor.finalityCallback);
-
-            this.logger.info(`Transaction ${tx.txHash} replaced with ${newTxInfo.txHash}`);
-        } else {
-            this.logger.error(`Failed to retry transaction ${tx.txHash} - will try again later`);
-        }
-    }
-
-    private async handleFinalizedTransaction(monitor: TransactionMonitor): Promise<void> {
-        const tx = monitor.transaction;
-        tx.status = TransactionStatus.Finalized;
-
-        this.logger.info(`Transaction ${tx.txHash} has reached finality on ${tx.chainName}`);
-
-        // Create a TransactionInfo for the finality callback
-        const finalizedTx: TransactionInfo = {
-            id: tx.managedTxId,
-            txHash: tx.txHash,
-            chainName: tx.chainName,
-            submittedAt: tx.firstSeen,
-            submissionBlock: tx.blockNumber,
-            status: 'finalized',
-        };
-
-        monitor.finalityCallback(finalizedTx);
-
-        // Remove from monitoring
         await this.removeMonitor(tx.txHash);
     }
 
@@ -301,33 +230,13 @@ export class TxMonitor implements ITxMonitor {
         return this.networkManager.getNetworkByName(chainName);
     }
 
-    private async checkNetworkTransactions(
-        networkName: string,
-        startBlock: bigint,
-        endBlock: bigint,
-    ): Promise<void> {
+    private async checkNetworkTransactions(networkName: string, endBlock: bigint): Promise<void> {
         const network = this.getNetwork(networkName);
         if (!network) return;
 
         const networkMonitors = Array.from(this.monitors.values()).filter(
             monitor => monitor.transaction.chainName === networkName,
         );
-
-        if (networkMonitors.length === 0) {
-            // Check if network has been idle long enough to unsubscribe
-            const lastActivity = this.networkLastActivity.get(networkName);
-            if (
-                lastActivity &&
-                Date.now() - lastActivity > (this.config.networkIdleThresholdMs || 3600000)
-            ) {
-                this.unsubscribeFromNetwork(networkName);
-                this.networkLastActivity.delete(networkName);
-            }
-            return;
-        }
-
-        // If there are active transactions, clear the idle timer
-        this.networkLastActivity.delete(networkName);
 
         const finalityConfirmations = BigInt(
             network.finalityConfirmations ?? this.networkManager.getDefaultFinalityConfirmations(),
@@ -367,7 +276,7 @@ export class TxMonitor implements ITxMonitor {
 
         const unsubscribe = blockManager.watchBlocks({
             onBlockRange: async (startBlock: bigint, endBlock: bigint) => {
-                await this.checkNetworkTransactions(networkName, startBlock, endBlock);
+                await this.checkNetworkTransactions(networkName, endBlock);
             },
             onError: (error: unknown) => {
                 this.logger.error(`Block monitoring error for ${networkName}:`, error);
@@ -375,36 +284,14 @@ export class TxMonitor implements ITxMonitor {
         });
 
         this.networkSubscriptions.set(networkName, unsubscribe);
-        this.networksWithTransactions.add(networkName);
         this.logger.debug(`Subscribed to blocks for network ${networkName}`);
-    }
-
-    private unsubscribeFromNetwork(networkName: string): void {
-        const unsubscribe = this.networkSubscriptions.get(networkName);
-        if (unsubscribe) {
-            unsubscribe();
-            this.networkSubscriptions.delete(networkName);
-            this.networksWithTransactions.delete(networkName);
-            this.logger.debug(`Unsubscribed from blocks for network ${networkName}`);
-        }
     }
 
     private async removeMonitor(txHash: string): Promise<void> {
         const monitor = this.monitors.get(txHash);
         if (!monitor) return;
 
-        const networkName = monitor.transaction.chainName;
         this.monitors.delete(txHash);
-
-        // Check if this network has any remaining transactions
-        const hasMoreTransactions = Array.from(this.monitors.values()).some(
-            m => m.transaction.chainName === networkName,
-        );
-
-        if (!hasMoreTransactions) {
-            // Record when transactions for this network ended
-            this.networkLastActivity.set(networkName, Date.now());
-        }
     }
 
     public async checkTransactionsInRange(
@@ -443,8 +330,6 @@ export class TxMonitor implements ITxMonitor {
         }
 
         this.networkSubscriptions.clear();
-        this.networksWithTransactions.clear();
-        this.networkLastActivity.clear();
         this.monitors.clear();
         this.logger.info('Disposed');
     }

--- a/src/managers/TxMonitor.ts
+++ b/src/managers/TxMonitor.ts
@@ -118,26 +118,6 @@ export class TxMonitor implements ITxMonitor {
         );
     }
 
-    public addTransaction(txHash: string, txInfo: TransactionInfo): void {
-        // This method is kept for backward compatibility but delegates to ensureTxFinality
-        this.logger.warn(`addTransaction called directly - use ensureTxFinality instead`);
-
-        // Create default callback for backward compatibility
-        const defaultCallback = (finalizedTx: TransactionInfo, isFinalized: boolean): void => {
-            if (isFinalized) {
-                this.logger.info(
-                    `Transaction ${finalizedTx.txHash} (${finalizedTx.id}) finalized (using legacy addTransaction)`,
-                );
-            } else {
-                this.logger.warn(
-                    `Transaction ${finalizedTx.txHash} (${finalizedTx.id}) failed (using legacy addTransaction)`,
-                );
-            }
-        };
-
-        this.ensureTxFinality(txInfo, defaultCallback);
-    }
-
     private async checkTransactionFinality(
         monitor: TransactionMonitor,
         currentBlock: bigint,

--- a/src/types/ManagerConfigs.ts
+++ b/src/types/ManagerConfigs.ts
@@ -18,6 +18,7 @@ export interface NetworkManagerConfig extends BaseManagerConfig {
         localhost: number[];
     };
     defaultConfirmations: number;
+    defaultFinalityConfirmations: number;
     mainnetUrl: string;
     testnetUrl: string;
 }

--- a/src/types/ManagerConfigs.ts
+++ b/src/types/ManagerConfigs.ts
@@ -49,6 +49,7 @@ export interface TxMonitorConfig extends BaseManagerConfig {
     checkIntervalMs?: number;
     dropTimeoutMs?: number;
     retryDelayMs?: number;
+	networkIdleThresholdMs?: number;
 }
 
 /** Configuration for NonceManager */

--- a/src/types/managers/INetworkManager.ts
+++ b/src/types/managers/INetworkManager.ts
@@ -13,6 +13,7 @@ export interface IConceroNetworkManager {
     getNetworkByName(name: string): ConceroNetwork;
     getNetworkBySelector(selector: string): ConceroNetwork;
     getVerifierNetwork(): ConceroNetwork | undefined;
+	getDefaultFinalityConfirmations(): number;
     forceUpdate(): Promise<void>;
     triggerInitialUpdates(): Promise<void>;
     registerUpdateListener(listener: NetworkUpdateListener): void;

--- a/src/types/managers/ITxMonitor.ts
+++ b/src/types/managers/ITxMonitor.ts
@@ -17,19 +17,15 @@ export interface TransactionInfo {
 export interface MonitoredTransaction {
     txHash: string;
     chainName: string;
+    submittedAt: number;
     blockNumber: bigint | null;
-    firstSeen: number;
-    lastChecked: number;
     status: string;
-    managedTxId: string;
 }
 
 export interface ITxMonitor {
-    watchTxFinality(
+    ensureTxFinality(
         txInfo: TransactionInfo,
-        retryCallback: (failedTx: TransactionInfo) => Promise<TransactionInfo | null>,
-        finalityCallback: (finalizedTx: TransactionInfo) => void,
-        canRetry?: boolean,
+        onFinalityCallback: (txInfo: TransactionInfo, isFinalized: boolean) => void,
     ): void;
     checkTransactionsInRange(
         network: ConceroNetwork,

--- a/src/types/managers/ITxMonitor.ts
+++ b/src/types/managers/ITxMonitor.ts
@@ -29,6 +29,7 @@ export interface ITxMonitor {
         txInfo: TransactionInfo,
         retryCallback: (failedTx: TransactionInfo) => Promise<TransactionInfo | null>,
         finalityCallback: (finalizedTx: TransactionInfo) => void,
+        canRetry?: boolean,
     ): void;
     checkTransactionsInRange(
         network: ConceroNetwork,


### PR DESCRIPTION
✅ Done:
- Added correct handling of finalityConfirmations to NetworkManager
- Changed the logic of TxMonitor operation (added work on subscription to BlockManager)
- Changed the logic of finality tracking.
- Removed retry logic.

Workflow:
1. Adding transaction → automatic subscription to network blocks via BlockManager.watchBlocks()
2. New blocks → check all transactions in the network for finality
3. Finality → finalityCallback call + monitor deletion (all subscribers are notified in case there were several subscribers in the transaction)

🔴 Backward compatibility:
- These changes affect the initialization of the TxManager and NetworkManager in consumers.
- API changed. Now the ensureTxFinality function, which returns the isFinalized flag, is responsible for tracking finalization instead of watchTxFinality.